### PR TITLE
Allow configuring which plugin types to build

### DIFF
--- a/plugins/MVerb/Makefile
+++ b/plugins/MVerb/Makefile
@@ -28,15 +28,32 @@ include ../../dpf/Makefile.plugins.mk
 # --------------------------------------------------------------
 # Enable all possible plugin types
 
+ifeq ($(HAVE_JACK),true)
 TARGETS += jack
+endif
+
+ifeq ($(BUILD_LADSPA),true)
 TARGETS += ladspa
+endif
+
+ifeq ($(BUILD_LV2),true)
+TARGETS += lv2_dsp
+ifeq ($(HAVE_DGL),true)
 TARGETS += lv2_sep
+endif
+endif
+
+ifeq ($(BUILD_VST),true)
 TARGETS += vst2
 TARGETS += vst3
+endif
 
+ifeq ($(BUILD_DSSI),true)
+TARGETS += dssi_dsp
 ifeq ($(HAVE_DGL),true)
 ifeq ($(HAVE_LIBLO),true)
-TARGETS += dssi
+TARGETS += dssi_ui
+endif
 endif
 endif
 


### PR DESCRIPTION
@falkTX Would you be open to including this in the Makefile? We've been using this patch (or a patch like this) for quiet some time in the package for gentoo.

Reason being that we want to give control to the user for what to build/compile and install.
Also I don't think it makes a lot of sense to install all the different plugin standards for a single plugin, that just clutters up a user's list of plugins with a lot of duplicates.